### PR TITLE
Detail to support twitter-bootstrap-saas as generated by yeoman

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -32,9 +32,7 @@ exports.runServer = function (grunt, options) {
 		grunt.util._.each(options.bases, function(b) {
 			middleware = middleware.concat([
 				// Serve static files.
-				connect.static(b),
-				// Make empty directories browsable.
-				connect.directory(b)
+				connect.static(b)
 			]);
 		});
 	}


### PR DESCRIPTION
Hi there and thanks for sharing grunt-express and grunt-express-example!
I used them to add to have express serve angular+twitter-bootstrap as generated by yeoman.

One thing that got in the way is the configuration of the static folders.
It turns out that making the directories browsable prevents the twitter-bootstrap with the saas flavor served from the '.tmp' to work as expected.

Here is the project where I am testing this:
https://github.com/hmalphettes/yeoman-angular-express-example

Let me know if I missed something trivial.
