### PR TITLE
socket.io example in README doesn't work with the latest grunt-express

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -139,7 +139,9 @@ exports.runServer = function runServer(grunt, options) {
       grunt.fatal('Server ["' + options.server + '"] -  ' + e);
     }
 
-    this.assignMiddlewaresPriority(server.stack, statics, middlewares);
+    if(server.stack) {
+      this.assignMiddlewaresPriority(server.stack, statics, middlewares);
+    }
 
     _.each(middlewares.concat(statics), function(mw) {
       server.use(mw);


### PR DESCRIPTION
You get this warning:
Warning: Cannot read property 'length' of undefined Use --force to continue.

I don't know if this fix is good or not but it seems to work with my setup.
