### PR TITLE
Error Stack option

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ Setting this option to `true` will tell `express` task to start a forever runnin
 
 When this options is not set (or set to `false`), the server will be running in the same process as grunt, and will only live as long as the grunt process is running. You may optionally use `express-keepalive` task to keep it alive.
 
+#### showStack
+Type: `Boolean`
+Default: `false`
+
+Setting this option to `true` will tell `express` task to show the full error stack, if an error occurs in your `express` server.
+
 #### watch (experimental)
 Type: `Object`
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -109,7 +109,8 @@ exports.runServer = function runServer(grunt, options) {
     port: 3000,
     // hostname: 'localhost',
     bases: null, // string|array of each static folders
-    server: null
+    server: null,
+    showStack: false
     // (optional) filepath that points to a module that exportss a 'server' object that provides
     // 1. a 'listen' function act like http.Server.listen (which connect.listen does)
     // 2. a 'use' function act like connect.use
@@ -136,7 +137,8 @@ exports.runServer = function runServer(grunt, options) {
         grunt.fatal('Server should provide a function called "use" that acts as connect.use');
       }
     } catch (e) {
-      grunt.fatal('Server ["' + options.server + '"] -  ' + e);
+      var errorMessage = options.showStack ? '\n' + e.stack : e;
+      grunt.fatal('Server ["' + options.server + '"] -  ' + errorMessage);
     }
 
     if(server.stack) {


### PR DESCRIPTION
Hi, at the moment if I have an error in my server or any dependent file, the error has the following format:

``` sh
Running "express-server:livereload:/var/folders/h7/hlgn4tkx017900b50c3slndh0000gn/T/express11385-3407-bt8fld/livereload.server" (express-server) task
Fatal error: Server ["/Users/tim/Dropbox/code/express-angular-test/server"] -  
ReferenceError: expors is not defined
```

In my example, the error came from a file, the main server requires. It is not possible to debug here.
My suggestion is to add a `showStack` option to enable the full error stack.
If the option is default to `true` or `false` is your decision, but I would at least offer the feature.

Thanks,
Tim Suchanek
