### PR TITLE
Actually use the hostname passed in for listening

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -179,7 +179,7 @@ exports.runServer = function runServer(grunt, options) {
 
     // always default hostname to 'localhost' would prevent access using IP address
     if (options.hostname) {
-      args.splice(1, options.hostname);
+      args.splice(1, 0, options.hostname);
     }
 
     server.listen.apply(server, args)


### PR DESCRIPTION
As was intended according to the docs.  Simple 3-char patch.
