### PR TITLE
Fix defects that resulted in the order of items in the processing pipeli...

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -14,12 +14,6 @@ exports.makeServerTaskName = function makeServerTaskName(serverName, kind) {
   return 'express_' + serverName + '_' + kind;
 }
 
-exports.rearrangeMiddleware = function rearrangeMiddleware(stackHolder) {
-  stackHolder.stack = (stackHolder.stack || []).sortBy(function(mw) {
-    return mw.handle.middlewarePriority || 99;
-  });
-}
-
 exports.watchModule = function watchModule(watcher) {
   // hijack each module extension handler, and watch the file
   function injectWatcher(handler) {
@@ -35,72 +29,40 @@ exports.watchModule = function watchModule(watcher) {
   }
 }
 
-exports.assignMiddlewaresPriority = function assignMiddlewaresPriority(main, statics, additionals) {
-  var staticsPlaceholderIndex = -1;
-  // find the `staticsPlaceholder` index from the group of middlewares injected by grunt config
-  additionals.each(function(mw, index) {
-    if (mw.name === 'staticsPlaceholder') {
-      staticsPlaceholderIndex = index;
-    }
-  });
-
-  var globalStaticsPlaceholderIndex = main.findIndex(function(mw) {
-    return mw.handle.name === 'staticsPlaceholder';
-  });
-  var middlewarePlaceholderIndex = main.findIndex(function(mw) {
-    return mw.handle.name === 'middlewarePlaceholder';
-  });
-
-  var mainStackPriorities = [1, 3, 5];
-  var dynamicStack = [];
-  var markers = [];
-  if (globalStaticsPlaceholderIndex === -1) {
-    if (staticsPlaceholderIndex !== -1) {
-      [].splice.apply(additionals, [staticsPlaceholder, 0].concat(statics));
-
-      dynamicStack.push(additionals.map(function(mw) {
-        mw.middlewarePriority = 2;
-      }));
-    } else {
-      dynamicStack.push(statics.concat(additionals).map(function(mw) {
-        mw.middlewarePriority = 2;
-      }));
-    }
-
-    if (middlewarePlaceholderIndex !== -1) {
-      markers = [middlewarePlaceholderIndex];
-    } else {
-      markers = [main.length - 1];
-    }
-  } else {
-    var temp;
-    if (globalStaticsPlaceholderIndex < middlewarePlaceholderIndex) {
-      temp = [statics, additionals];
-      markers = [globalStaticsPlaceholderIndex, middlewarePlaceholderIndex];
-    } else if (middlewarePlaceholderIndex !== -1) {
-      temp = [additionals, statics];
-      markers = [middlewarePlaceholderIndex, globalStaticsPlaceholderIndex];
-    } else {
-      temp = [statics, additionals];
-      markers = [globalStaticsPlaceholderIndex, main.length - 1];
-    }
-
-    dynamicStack.push(temp[0].map(function(mw) {
-      mw.middlewarePriority = 2;
-    }));
-    dynamicStack.push(temp[1].map(function(mw) {
-      mw.middlewarePriority = 4;
-    }));
+function insertMiddleware(server, index, middlewares) {
+  if (middlewares.length == 0) {
+    return; // nothing to do
   }
-
-  var i = 0;
-  var j = 0;
-  while (j < markers.length) {
-    while (i < markers[j]) {
-      main[i++].handle.middlewarePriority = mainStackPriorities[j];
-    }
-    j++;
+  var stackHolder = server._router || server;
+  var stackCount = stackHolder.stack.length;
+  middlewares.each(function (mw) {
+    server.use(mw);
+  });
+  if (0 <= index && index < stackCount) { // need to reposition inserted items
+    var insertedMiddleware = stackHolder.stack.splice(stackCount);
+    [].splice.apply(stackHolder.stack, [index, 0].concat(insertedMiddleware));
   }
+}
+
+function findPlaceholder(server, placeholderName) {
+  var stackHolder = server._router || server;
+  return stackHolder.stack.findIndex(function (mw) {
+    return mw.handle.name === placeholderName;
+  });
+}
+
+function dumpStack(label, server) {
+  var stackHolder = server._router || server;
+  console.log(label);
+  var items = [];
+  stackHolder.stack.each(function (item) {
+    var obj = {
+      handle: item.handle,
+      path: item.route && item.route.path
+    };
+    items.push(obj);
+  });
+  console.log(items);
 }
 
 exports.runServer = function runServer(grunt, options) {
@@ -125,7 +87,7 @@ exports.runServer = function runServer(grunt, options) {
     });
   }
 
-  var server, stackHolder;
+  var server;
   if (options.server) {
     try {
       server = require(path.resolve(options.server));
@@ -139,30 +101,23 @@ exports.runServer = function runServer(grunt, options) {
       var errorMessage = options.showStack ? '\n' + e.stack : e;
       grunt.fatal('Server ["' + options.server + '"] -  ' + errorMessage);
     }
-
-    stackHolder = server._router || server;
-    if(stackHolder.stack) {
-      this.assignMiddlewaresPriority(stackHolder.stack, statics, middlewares);
-    }
-
-    middlewares.concat(statics).each(function(mw) {
-      server.use(mw);
-    })
   } else {
-    server = connect.apply(null, statics.concat(middlewares));
-    stackHolder = server._router || server;
+    server = connect();
   }
+
+//  dumpStack('BEFORE', server);
+  insertMiddleware(server, findPlaceholder(server, 'middlewarePlaceholder'), middlewares);
+//  dumpStack('AFTER middleware', server);
+  insertMiddleware(server, findPlaceholder(server, 'staticsPlaceholder'), statics);
+//  dumpStack('AFTER statics', server);
 
   if (options.livereload && options.insertConnectLivereload !== false) {
     var lr = require('connect-livereload')({
       port: options.livereload
     });
-    lr.middlewarePriority = -1;
-    server.use(lr);
+    insertMiddleware(server, 0, [lr]);
+//    dumpStack('AFTER livereload', server);
   }
-
-  this.rearrangeMiddleware(stackHolder);
-  // console.log(stackHolder.stack)
 
   if (options.hostname === '*') {
     delete options.hostname;

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "grunt-contrib-nodeunit": "^0.3.3",
     "grunt": "^0.4.4",
     "matchdep": "^0.3.0",
-    "request": "^2.34.0"
+    "request": "^2.34.0",
+    "lodash": "~2.4.1"
   },
   "peerDependencies": {
     "grunt": "~0.4.0"

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,2 +1,106 @@
 // reuse test/helper.js from `grunt-contrib-watch`
-var helper = module.exports = require('grunt-contrib-watch/test/tasks/helper');
+var grunt = require('grunt');
+var path = require('path');
+var _ = require('lodash');
+
+module.exports = helper = {};
+
+// where are fixtures are
+helper.fixtures = path.join(__dirname, '..', 'fixtures');
+
+// If verbose flag set, display output
+helper.verboseLog = function() {};
+if (_.indexOf(process.argv, '-v') !== -1) {
+  helper.verboseLog = function() { console.log.apply(null, arguments); };
+}
+
+// helper for creating assertTasks for testing tasks in child processes
+helper.assertTask = function assertTask(task, options) {
+  var spawn = require('child_process').spawn;
+  task = task || 'default';
+  options = options || {};
+
+  // get next/kill process trigger
+  var trigger = options.trigger || '.*(Waiting).*';
+  delete options.trigger;
+
+  // CWD to spawn
+  var cwd = options.cwd || process.cwd();
+  delete options.cwd;
+
+  // Use grunt this process uses
+  var spawnOptions = [process.argv[1]];
+  // Turn options into spawn options
+  _.each(options, function(val, key) {
+    spawnOptions.push('--' + key);
+    spawnOptions.push(val);
+  });
+  // Add the tasks to run
+  spawnOptions = spawnOptions.concat(task);
+
+  // Return an interface for testing this task
+  function returnFunc(runs, done) {
+    // Spawn the node this process uses
+    var spawnGrunt = spawn(process.argv[0], spawnOptions, {cwd:cwd});
+    var out = '';
+
+    if (!Array.isArray(runs)) {
+      runs = [runs];
+    }
+
+    // Append a last function to kill spawnGrunt
+    runs.push(function() {
+      spawnGrunt.kill('SIGINT');
+    });
+
+    // After watch starts waiting, run our commands then exit
+    spawnGrunt.stdout.on('data', function(data) {
+      data = grunt.log.uncolor(String(data));
+      out += data;
+
+      // If we should run the next function
+      var shouldRun = true;
+
+      // If our trigger has been found
+      if (trigger !== false) {
+        shouldRun = (new RegExp(trigger, 'gm')).test(data);
+      }
+
+      // Run the function
+      if (shouldRun) {
+        setTimeout(function() {
+          var run = runs.shift();
+          if (typeof run === 'function') { run(); }
+        }, 500);
+      }
+    });
+
+    // Throw errors for better testing
+    spawnGrunt.stderr.on('data', function(data) {
+      throw new Error(data);
+    });
+
+    // On process exit return what has been outputted
+    spawnGrunt.on('exit', function() {
+      done(out);
+    });
+  }
+  returnFunc.options = options;
+  return returnFunc;
+};
+
+// clean up files within fixtures
+helper.cleanUp = function cleanUp(files) {
+  if (typeof files === 'string') files = [files];
+  files.forEach(function(filepath) {
+    filepath = path.join(helper.fixtures, filepath);
+    if (grunt.file.exists(filepath)) {
+      grunt.file.delete(filepath);
+    }
+  });
+};
+
+// Helper for testing cross platform
+helper.unixify = function(str) {
+  return str.replace(/\\/g, '/').replace(/\r\n|\n/g, '\n');
+};


### PR DESCRIPTION
...ne to be changed.

The sort method for updating the processing middleware pipeline was occasionally rearranging the items (weren't getting assigned a middlewarePriority).  I've simplified the method by simply appending the new middleware to the end of the pipeline and then moving it to the appropriate place in the pipeline.

Also, got the tests working again by copying the missing file from grunt-contrib-watch
