### PR TITLE
Allow "connect-like" object to be passed to grunt-express as the "server"

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ app.use(function staticsPlaceholder(req, res, next) {
 ```
 
 #### server
-Type: `String`
+Type: `String|Object`
 Default: null
 
-This option allows you to specify a path to a Node.js module that exports a "connect-like" object. Such object should have the following two functions:
+This option allows you to specify a "connect-like" object. This can optionally be a path to a Node.js module that exports a such an object. Such object should have the following two functions:
 
 1. `use(route, fn)` (https://github.com/senchalabs/connect/blob/master/lib/proto.js#L62)
 2. `listen()` (https://github.com/senchalabs/connect/blob/master/lib/proto.js#L227)

--- a/lib/util.js
+++ b/lib/util.js
@@ -96,6 +96,8 @@ exports.runServer = function runServer(grunt, options) {
         var errorMessage = options.showStack ? '\n' + e.stack : e;
         grunt.fatal('Server ["' + options.server + '"] -  ' + errorMessage);
       }
+    } else {
+      server = options.server;
     }
 
     if (typeof server.listen !== 'function') {

--- a/lib/util.js
+++ b/lib/util.js
@@ -89,17 +89,20 @@ exports.runServer = function runServer(grunt, options) {
 
   var server;
   if (options.server) {
-    try {
-      server = require(path.resolve(options.server));
-      if (typeof server.listen !== 'function') {
-        grunt.fatal('Server should provide a function called "listen" that acts as http.Server.listen');
+    if (typeof options.server === 'string') {
+      try {
+        server = require(path.resolve(options.server));
+      } catch (e) {
+        var errorMessage = options.showStack ? '\n' + e.stack : e;
+        grunt.fatal('Server ["' + options.server + '"] -  ' + errorMessage);
       }
-      if (typeof server.use !== 'function') {
-        grunt.fatal('Server should provide a function called "use" that acts as connect.use');
-      }
-    } catch (e) {
-      var errorMessage = options.showStack ? '\n' + e.stack : e;
-      grunt.fatal('Server ["' + options.server + '"] -  ' + errorMessage);
+    }
+
+    if (typeof server.listen !== 'function') {
+      grunt.fatal('Server should provide a function called "listen" that acts as http.Server.listen');
+    }
+    if (typeof server.use !== 'function') {
+      grunt.fatal('Server should provide a function called "use" that acts as connect.use');
     }
   } else {
     server = connect();


### PR DESCRIPTION
Allow "connect-like" object to be passed to grunt-express as the "server" rather than just a string.

This allows for grunt to pass configuration to the server, such as things from grunt.option or whatever it desires, and then build out the server and pass back the ready-object.

My use case for this is that I am building a grunt plugin which performs client-side unit testing. This plugin consumes grunt-express to start a localhost web server which generates the HTML pages for the tests. I want to pass in the list of dependencies for each test file to the web server from Grunt, or at least the paths where the test files live which are configured in the user's Gruntfile.js - currently there is no way for me to pass data to the server.js from grunt-express.

An example of how to use this:

_Gruntfile.js_

``` js
var path = require('path');

module.exports = function(grunt) {
  grunt.initConfig({
    testEnvironment: {
      // define the root of your project files
      root: path.join(__dirname, 'src'),
      // define the pattern to identify your unit tests
      pattern: '**/*.unittests.js',
      // define your global dependencies, relative to your root project
      deps: [
        '3rdparty/jquery.js'
      ]
    }
  });
};
```

_testEnvironment.js - grunt task consuming grunt-express_

``` js
var path = require('path');

module.exports = function (grunt) {

  grunt.registerTask('testEnvironment', function () {
    var options = this.options({
      deps: []
    });

    var config = {
      // find all the test files matching the options
      tests: findTests(options),
      deps: options.deps
    };

    grunt.config.set('express:testEnvironment', {
      options: {
        port: 3000,
        server: require(path.join(__dirname, 'lib', 'server.js'))(config)
      }
    });

    grunt.task.run('express:testEnvironment');
  });
};
```

_server.js_

``` js
var express = require('express')
var app = express();

module.exports = function (config) {
    // do stuff now
    return app;
};
```

Currently there would be no way to pass configuration to the server prior to it starting. This allows that to happen. There are existing hooks to pass in middleware from grunt, but no way to do more advanced configuration. This allows the system to be a lot more robust.
