### PR TITLE
Use latest version of grunt-contrib-watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "temp": "^0.7.0",
     "touch": "0.0.3",
     "connect-livereload": "^0.4.0",
-    "grunt-contrib-watch": "^0.6.1",
+    "grunt-contrib-watch": "^1.0.0",
     "open": "0.0.5",
     "grunt-parallel": "^0.3.1",
     "sugar": "^1.4.1"


### PR DESCRIPTION
grunt-contrib-watch@0.61 has the following branch in its dependency tree:
  └─┬ grunt-contrib-watch@0.6.1
    └─┬ gaze@0.5.2
      └─┬ globule@0.1.0
        └── lodash@1.0.2

lodash@1.0.2 is no longer maintained (as are all lodash
versions < 3.0.0, according to an npm warning). grunt-contrib-watch 1.0.0
ultimately depends on lodash 4.9.0, which is still maintained.
